### PR TITLE
Add rate limiting functionality with RateLimitingFilter and register …

### DIFF
--- a/src/main/java/io/github/dhar135/WeatherApi/WeatherApiApplication.java
+++ b/src/main/java/io/github/dhar135/WeatherApi/WeatherApiApplication.java
@@ -2,7 +2,11 @@ package io.github.dhar135.WeatherApi;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+
+import io.github.dhar135.WeatherApi.config.RateLimitingFilter;
 
 @EnableCaching
 @SpringBootApplication
@@ -11,6 +15,14 @@ public class WeatherApiApplication {
 	public static void main(String[] args) {
 		SpringApplication.run(WeatherApiApplication.class, args);
 
+	}
+
+	@Bean
+	public FilterRegistrationBean<RateLimitingFilter> rateLimitingFilter() {
+		FilterRegistrationBean<RateLimitingFilter> registration = new FilterRegistrationBean<>();
+		registration.setFilter(new RateLimitingFilter());
+		registration.addUrlPatterns("/api/weather/*");
+		return registration;
 	}
 
 }

--- a/src/main/java/io/github/dhar135/WeatherApi/WeatherApiApplication.java
+++ b/src/main/java/io/github/dhar135/WeatherApi/WeatherApiApplication.java
@@ -22,6 +22,7 @@ public class WeatherApiApplication {
 		FilterRegistrationBean<RateLimitingFilter> registration = new FilterRegistrationBean<>();
 		registration.setFilter(new RateLimitingFilter());
 		registration.addUrlPatterns("/api/weather/*");
+		registration.setOrder(1);
 		return registration;
 	}
 

--- a/src/main/java/io/github/dhar135/WeatherApi/config/RateLimitingFilter.java
+++ b/src/main/java/io/github/dhar135/WeatherApi/config/RateLimitingFilter.java
@@ -46,9 +46,10 @@ public class RateLimitingFilter implements Filter {
             return;
         }
 
-        // Reset request counts periodically
-        if (requests % MAX_REQUESTS_PER_MINUTE == 0) {
-            requestCounts.remove(ipAddress);
+        // Reset request counts periodically every minute
+        if (System.currentTimeMillis() - lastResetTime > 60000) {
+            requestCounts.clear();
+            lastResetTime = System.currentTimeMillis();
         }
 
         // Set the request count in the response header

--- a/src/main/java/io/github/dhar135/WeatherApi/config/RateLimitingFilter.java
+++ b/src/main/java/io/github/dhar135/WeatherApi/config/RateLimitingFilter.java
@@ -1,0 +1,61 @@
+package io.github.dhar135.WeatherApi.config;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.springframework.http.HttpStatus;
+
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+public class RateLimitingFilter implements Filter {
+
+    // Map to store the number of requests per IP address
+    private final Map<String, AtomicInteger> requestCounts = new ConcurrentHashMap<>();
+
+    // Maximum number of requests per IP address
+    private final static int MAX_REQUESTS_PER_MINUTE = 5;
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+        HttpServletRequest httpRequest = (HttpServletRequest) request;
+        HttpServletResponse httpResponse = (HttpServletResponse) response;
+
+        // Get the IP address of the request
+        String ipAddress = httpRequest.getRemoteAddr();
+
+        // Initialize the request count for the IP address if it doesn't exist
+        requestCounts.putIfAbsent(ipAddress, new AtomicInteger(0));
+        AtomicInteger requestCount = requestCounts.get(ipAddress);
+
+        // Increment the request count
+        int requests = requestCount.incrementAndGet();
+
+        // Check if the request limit has been exceeded
+        if (requests > MAX_REQUESTS_PER_MINUTE) {
+            httpResponse.setStatus(HttpStatus.TOO_MANY_REQUESTS.value());
+            httpResponse.getWriter().write("Too many requests");
+            return;
+        }
+
+        // Reset request counts periodically
+        if (requests % MAX_REQUESTS_PER_MINUTE == 0) {
+            requestCounts.remove(ipAddress);
+        }
+
+        // Set the request count in the response header
+        httpResponse.setHeader("X-Rate-Limit-Remaining", String.valueOf(MAX_REQUESTS_PER_MINUTE - requests));
+
+        // Continue with the request
+        chain.doFilter(request, response);
+    }
+
+}


### PR DESCRIPTION
This pull request introduces a rate-limiting feature to the Weather API application. The changes include the addition of a custom `RateLimitingFilter` class to enforce a limit on the number of requests per IP address and the integration of this filter into the application via a `FilterRegistrationBean`. 

### Rate Limiting Feature:

* **Custom Rate-Limiting Filter**: Added the `RateLimitingFilter` class to enforce a limit of 5 requests per minute per IP address. The filter tracks request counts using a `ConcurrentHashMap`, responds with `429 Too Many Requests` if the limit is exceeded, and includes the remaining request count in the `X-Rate-Limit-Remaining` response header. (`src/main/java/io/github/dhar135/WeatherApi/config/RateLimitingFilter.java`)

* **Filter Registration**: Introduced a `FilterRegistrationBean` in the `WeatherApiApplication` class to register the `RateLimitingFilter` for the `/api/weather/*` endpoint. This ensures the filter is applied to relevant API routes. (`src/main/java/io/github/dhar135/WeatherApi/WeatherApiApplication.java`)

### Dependency Updates:

* **Imports for Filter Registration**: Added necessary imports for `FilterRegistrationBean` and the `RateLimitingFilter` class in `WeatherApiApplication.java`. (`src/main/java/io/github/dhar135/WeatherApi/WeatherApiApplication.java`)